### PR TITLE
added getChildByAttribute to BaseNode.

### DIFF
--- a/siptracklib/treenodes.py
+++ b/siptracklib/treenodes.py
@@ -450,7 +450,7 @@ class BaseNode(object):
 
         Basically identical in funcationallity to a server side search,
         but only searches in the local tree, no server querying at all.
-        
+
         Search the node tree for nodes attributes that match the regular
         expression re_pattern.
 
@@ -491,6 +491,12 @@ class BaseNode(object):
                         node_filter.result_match:
                     yield node
                     prev_added = node
+
+    def getChildByAttribute(self, attribute, value, include = [], exclude = []):
+        for node in self.listChildren(include = include, exclude = exclude):
+            if attribute in node.attributes._listAttributes():
+                if node.attributes.get(attribute) == value:
+                    return node
 
     def getChildByName(self, name, include = [], exclude = []):
         for node in self.listChildren(include = include, exclude = exclude):


### PR DESCRIPTION
Needed this method for an import I was doing from vcenter to siptrack. 

This helps me find duplicate siptrack devices by searching for the attribute vcenter uuid by value. 
